### PR TITLE
Fix test file

### DIFF
--- a/test_expected_output.txt
+++ b/test_expected_output.txt
@@ -26,7 +26,6 @@ Valid set options (and command line equivalents) are:
 	options
 	create (-c), nocreate
 	prompt, noprompt (-q)
-	interactive (-i), nointeractive
 	ritchie (-r), preansi (-p), ansi (-a) or cplusplus (-+)
 
 Current set values are:


### PR DESCRIPTION
In the current state, the tests are failing due to an extra `interactive (-i), nointeractive` line missing.

```
$ make test
--- -   2024-05-07 03:43:06.253027240 +0000
+++ test_expected_output.txt    1970-01-01 00:00:01.000000000 +0000
@@ -26,6 +26,7 @@
        options
        create (-c), nocreate
        prompt, noprompt (-q)
+       interactive (-i), nointeractive
        ritchie (-r), preansi (-p), ansi (-a) or cplusplus (-+)
 
 Current set values are:
** Test failed **
make: *** [Makefile:48: test] Error 1
```