### PR TITLE
Accept `explain static volatile int x`

### DIFF
--- a/cdgram.y
+++ b/cdgram.y
@@ -20,7 +20,7 @@ char cdgramsccsid[] = "@(#)cdgram.y	2.2 3/30/88";
 %token <dynstr> NUMBER SHORT SIGNED STRUCT UNION UNSIGNED VOID
 %token <dynstr> AUTO EXTERN REGISTER STATIC
 %type <dynstr> adecllist adims c_type cast castlist cdecl cdecl1 cdims
-%type <dynstr> constvol_list ClassStruct mod_list mod_list1 modifier
+%type <dynstr> ClassStruct mod_list mod_list1 modifier
 %type <dynstr> opt_constvol_list optNAME opt_storage storage StrClaUniEnum
 %type <dynstr> tname type
 %type <halves> adecl
@@ -84,15 +84,25 @@ stmt		: HELP NL
 			docast(NullCP, $2.left, $2.right, $2.type);
 			}
 
-		| EXPLAIN opt_storage opt_constvol_list type opt_constvol_list cdecl NL
+		| EXPLAIN storage opt_constvol_list type opt_constvol_list cdecl NL
 			{
-			Debug((stderr, "stmt: EXPLAIN opt_storage opt_constvol_list type cdecl\n"));
-			Debug((stderr, "\topt_storage='%s'\n", $2));
+			Debug((stderr, "stmt: EXPLAIN storage opt_constvol_list type cdecl\n"));
+			Debug((stderr, "\tstorage='%s'\n", $2));
 			Debug((stderr, "\topt_constvol_list='%s'\n", $3));
 			Debug((stderr, "\ttype='%s'\n", $4));
 			Debug((stderr, "\tcdecl='%s'\n", $6));
 			Debug((stderr, "\tprev = '%s'\n", visible(prev)));
 			dodexplain($2, $3, $5, $4, $6);
+			}
+
+		| EXPLAIN opt_constvol_list type opt_constvol_list cdecl NL
+			{
+			Debug((stderr, "stmt: EXPLAIN opt_constvol_list type cdecl\n"));
+			Debug((stderr, "\topt_constvol_list='%s'\n", $2));
+			Debug((stderr, "\ttype='%s'\n", $3));
+			Debug((stderr, "\tcdecl='%s'\n", $5));
+			Debug((stderr, "\tprev = '%s'\n", visible(prev)));
+			dodexplain(ds(""), $2, $4, $3, $5);
 			}
 
 		| EXPLAIN storage opt_constvol_list cdecl NL
@@ -105,14 +115,13 @@ stmt		: HELP NL
 			dodexplain($2, $3, ds(""), NullCP, $4);
 			}
 
-		| EXPLAIN opt_storage constvol_list cdecl NL
+		| EXPLAIN opt_constvol_list cdecl NL
 			{
-			Debug((stderr, "stmt: EXPLAIN opt_storage constvol_list cdecl\n"));
-			Debug((stderr, "\topt_storage='%s'\n", $2));
-			Debug((stderr, "\tconstvol_list='%s'\n", $3));
-			Debug((stderr, "\tcdecl='%s'\n", $4));
+			Debug((stderr, "stmt: EXPLAIN opt_constvol_list cdecl\n"));
+			Debug((stderr, "\topt_constvol_list='%s'\n", $2));
+			Debug((stderr, "\tcdecl='%s'\n", $3));
 			Debug((stderr, "\tprev = '%s'\n", visible(prev)));
-			dodexplain($2, $3, ds(""), NullCP, $4);
+			dodexplain(ds(""), $2, ds(""), NullCP, $3);
 			}
 
 		| EXPLAIN '(' opt_constvol_list type cast ')' optNAME NL
@@ -904,21 +913,6 @@ opt_constvol_list: CONSTVOLATILE opt_constvol_list
 			{
 			Debug((stderr, "opt_constvol_list: EMPTY\n"));
 			$$ = ds("");
-			}
-		;
-
-constvol_list: CONSTVOLATILE opt_constvol_list
-			{
-			Debug((stderr, "constvol_list: CONSTVOLATILE opt_constvol_list\n"));
-			Debug((stderr, "\tCONSTVOLATILE='%s'\n", $1));
-			Debug((stderr, "\topt_constvol_list='%s'\n", $2));
-			if (PreANSIFlag)
-				notsupported(" (Pre-ANSI Compiler)", $1, NullCP);
-			else if (RitchieFlag)
-				notsupported(" (Ritchie Compiler)", $1, NullCP);
-			else if ((strcmp($1, "noalias") == 0) && CplusplusFlag)
-				unsupp($1, NullCP);
-			$$ = cat($1,ds(strlen($2) ? " " : ""),$2,NullCP);
 			}
 		;
 

--- a/testset.txt
+++ b/testset.txt
@@ -17,6 +17,7 @@ declare x as func(pointer to char) ret pointer to int
 declare x as func(int) ret pointer to int
 declare x as func(pointer to char, int) ret pointer to int
 declare x as function (args) returning pointer to int
+declare x as static volatile int
 
 # test some explain functions
 explain char *x
@@ -28,6 +29,8 @@ explain int X::*foo
 explain class Y *(X::*foo)(arg1, arg2)
 explain int *x()
 explain int *x(args)
+explain static volatile int x
+explain static const long int volatile *x
 explain int *x(char *)
 explain int *x(char *, int)
 explain int *x(char *, int, float)

--- a/testset.txt
+++ b/testset.txt
@@ -18,6 +18,21 @@ declare x as func(int) ret pointer to int
 declare x as func(pointer to char, int) ret pointer to int
 declare x as function (args) returning pointer to int
 declare x as static volatile int
+declare x as char
+declare x as signed char
+declare x as unsigned char
+declare x as short
+declare x as short int
+declare x as signed short
+declare x as signed short int
+declare x as signed
+declare x as unsigned
+declare x as long
+declare x as long int
+declare x as unsigned long
+declare x as unsigned long int
+declare x as unsigned long long
+declare x as unsigned long long int
 
 # test some explain functions
 explain char *x
@@ -39,6 +54,21 @@ explain const int x
 explain int const x
 explain static x
 explain const x
+explain char x
+explain signed char x
+explain unsigned char x
+explain short x
+explain short int x
+explain signed short x
+explain signed short int x
+explain signed x
+explain unsigned x
+explain long x
+explain long int x
+explain unsigned long x
+explain unsigned long int x
+explain unsigned long long x
+explain unsigned long long int x
 
 # test some casts
 cast x into void

--- a/testset_cpp_expected_output.txt
+++ b/testset_cpp_expected_output.txt
@@ -52,6 +52,7 @@ int *x(char *)
 int *x(int)
 int *x(char *, int)
 int *x(args)
+static volatile int x
 declare x as pointer to char
 declare x as array of int
 declare x as array 4 of int
@@ -61,6 +62,8 @@ declare foo as pointer to member of class X int
 declare foo as pointer to member of class X function (arg1, arg2) returning pointer to class Y
 declare x as function returning pointer to int
 declare x as function (args) returning pointer to int
+declare x as static volatile int
+declare x as static pointer to const volatile long int
 declare x as function (pointer to char) returning pointer to int
 declare x as function (pointer to char, int) returning pointer to int
 declare x as function (pointer to char, int, float) returning pointer to int

--- a/testset_cpp_expected_output.txt
+++ b/testset_cpp_expected_output.txt
@@ -53,6 +53,21 @@ int *x(int)
 int *x(char *, int)
 int *x(args)
 static volatile int x
+char x
+signed char x
+unsigned char x
+short x
+short int x
+signed short x
+signed short int x
+signed x
+unsigned x
+long x
+long int x
+unsigned long x
+unsigned long int x
+unsigned long long x
+unsigned long long int x
 declare x as pointer to char
 declare x as array of int
 declare x as array 4 of int
@@ -72,6 +87,21 @@ declare x as const int
 declare x as const int
 declare x as static int
 declare x as const int
+declare x as char
+declare x as signed char
+declare x as unsigned char
+declare x as short
+declare x as short int
+declare x as signed short
+declare x as signed short int
+declare x as signed
+declare x as unsigned
+declare x as long
+declare x as long int
+declare x as unsigned long
+declare x as unsigned long int
+declare x as unsigned long long
+declare x as unsigned long long int
 (void)x
 (char *)x
 (int (*)[4])x

--- a/testset_expected_output.txt
+++ b/testset_expected_output.txt
@@ -55,6 +55,7 @@ int *x(char *)
 int *x(int)
 int *x(char *, int)
 int *x(args)
+static volatile int x
 declare x as pointer to char
 declare x as array of int
 declare x as array 4 of int
@@ -66,6 +67,8 @@ Warning: Unsupported in C -- 'pointer to member of class'
 declare foo as pointer to member of class X function (arg1, arg2) returning pointer to class Y
 declare x as function returning pointer to int
 declare x as function (args) returning pointer to int
+declare x as static volatile int
+declare x as static pointer to const volatile long int
 declare x as function (pointer to char) returning pointer to int
 declare x as function (pointer to char, int) returning pointer to int
 declare x as function (pointer to char, int, float) returning pointer to int

--- a/testset_expected_output.txt
+++ b/testset_expected_output.txt
@@ -56,6 +56,21 @@ int *x(int)
 int *x(char *, int)
 int *x(args)
 static volatile int x
+char x
+signed char x
+unsigned char x
+short x
+short int x
+signed short x
+signed short int x
+signed x
+unsigned x
+long x
+long int x
+unsigned long x
+unsigned long int x
+unsigned long long x
+unsigned long long int x
 declare x as pointer to char
 declare x as array of int
 declare x as array 4 of int
@@ -77,6 +92,21 @@ declare x as const int
 declare x as const int
 declare x as static int
 declare x as const int
+declare x as char
+declare x as signed char
+declare x as unsigned char
+declare x as short
+declare x as short int
+declare x as signed short
+declare x as signed short int
+declare x as signed
+declare x as unsigned
+declare x as long
+declare x as long int
+declare x as unsigned long
+declare x as unsigned long int
+declare x as unsigned long long
+declare x as unsigned long long int
 (void)x
 (char *)x
 (int (*)[4])x


### PR DESCRIPTION
This still fails to accept `explain volatile static int x`, which is in fact legal C and C++.

Add tests for type modifiers (signed, unsigned, long, short).
    
Really, `long long int` shouldn't print any differently from `signed long long`, and `long volatile int` should be accepted, and `long long long` should be rejected; but that would take a lot of work that I'm not planning to do right now.

FWIW, here's the work I'm not doing: I think the `modbits` hack should be extended to handle all [_decl-specifiers_](https://eel.is/c++draft/dcl.spec.general#nt:decl-specifier), not just the [_simple-type-specifiers_](https://eel.is/c++draft/dcl.type.simple#nt:simple-type-specifier) but also the [_storage-class-specifiers_](https://eel.is/c++draft/dcl.stc#nt:storage-class-specifier). Then the way `explain` pretty-prints the declaration should be reconstituted from `modbits` in [canonical order](https://quuxplusone.github.io/blog/2021/04/03/static-constexpr-whittling-knife/), rather than echoing the bag of strings in the order the user gave them to us. So e.g. `explain long unsigned x` _should_ print `declare x as unsigned long int`, not `declare x as long unsigned`. To reject `long long long`, we should add `MB_LONGLONG` such that two `MB_LONG`s make an `MB_LONGLONG`, and then record in the crosscheck table that `MB_LONGLONG` is incompatible with `MB_LONG`.

Fixes #1